### PR TITLE
In-place version

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -13,8 +13,8 @@ AMD = "0.4, 0.5"
 
 [extras]
 AMD = "14f7f29c-3bd6-536c-9a0b-7339e30b5a3e"
-Metis = "2679e427-3c69-5b7f-982b-ece356f1e94b"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+Metis = "2679e427-3c69-5b7f-982b-ece356f1e94b"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 

--- a/src/LimitedLDLFactorizations.jl
+++ b/src/LimitedLDLFactorizations.jl
@@ -48,6 +48,8 @@ mutable struct LimitedLDLFactorization{T <: Real, Ti <: Integer, V1 <: AbstractV
   list::Vector{Ti}
   pos::Vector{Ti}
   neg::Vector{Ti}
+
+  computed_posneg::Bool # true if pos and neg are computed (becomes false after factorization)
 end
 
 lldl(A::Array{Tv, 2}; kwargs...) where {Tv <: Number} = lldl(sparse(A); kwargs...)
@@ -147,6 +149,7 @@ function LimitedLDLFactorization(
     list,
     pos,
     neg,
+    true,
   )
 end
 
@@ -287,16 +290,19 @@ function lldl_factorize!(
   neg = S.neg
   cpos = 0
   cneg = 0
-  for i=1:n
-    adiagPi = adiag[P[i]]
-    if adiagPi > Tv(0)
-      cpos += 1 
-      pos[cpos] = i
-    else
-      cneg += 1
-      neg[cneg] = i
+  if !(S.computed_posneg)
+    for i=1:n
+      adiagPi = adiag[P[i]]
+      if adiagPi > Tv(0)
+        cpos += 1 
+        pos[cpos] = i
+      else
+        cneg += 1
+        neg[cneg] = i
+      end
     end
   end
+  S.computed_posneg = false
 
   while !(factorized || tired)
 

--- a/src/LimitedLDLFactorizations.jl
+++ b/src/LimitedLDLFactorizations.jl
@@ -21,7 +21,7 @@ The modified version is described in [3,4].
 """
 module LimitedLDLFactorizations
 
-export lldl, lldl_allocate, lldl_factorize!, \, ldiv!, nnz, LimitedLDLFactorization
+export lldl, lldl_factorize!, \, ldiv!, nnz, LimitedLDLFactorization
 
 using AMD, LinearAlgebra, SparseArrays
 
@@ -154,7 +154,7 @@ function LimitedLDLFactorization(
 end
 
 """
-    lldl_allocate(T, adiag, P; memory = 0, α = 0.0)
+    LLDL = LimitedLDLFactorization(T, adiag, P; memory = 0, α = 0.0)
 
 Perform the allocations for the LLDL factorization of symmetric matrix whose lower triangle is `T` 
 and diagonal is `d` with the permutation vector `P`.
@@ -172,7 +172,7 @@ and diagonal is `d` with the permutation vector `P`.
                  factorization of `A` is found to not exist. The shift will be
                  gradually increased from this initial value until success.
 """
-function lldl_allocate(
+function LimitedLDLFactorization(
   T::SparseMatrixCSC{Tv, Ti},
   adiag::AbstractVector{Tv},
   P::AbstractVector{<:Integer};
@@ -196,15 +196,15 @@ end
 
 # Here T is the strict lower triangle of A.
 """
-    lldl_factorize!(T, adiag, S; droptol = 0.0)
+    lldl_factorize!(S, T, adiag; droptol = 0.0)
 
 Perform the in-place factorization of a symmetric matrix whose lower triangle is `T` and diagonal is `d` 
 with the permutation vector.
 
 # Arguments
+- `S::LimitedLDLFactorization{Tv, Ti}`.
 - `T::SparseMatrixCSC{Tv,Ti}`: lower triangle of the matrix to factorize.
 - `adiag::AbstractVector{Tv}`: diagonal of the matrix to factorize.
-- `S::LimitedLDLFactorization{Tv, Ti}`: computed with [`LimitedLDLFactorizations.lldl_allocate`](@ref).
 `T` should keep the same nonzero pattern and `adiag` should keep the sign of its elements.
 
 # Keyword arguments
@@ -212,9 +212,9 @@ with the permutation vector.
                        than `droptol` are dropped.
 """
 function lldl_factorize!(
+  S::LimitedLDLFactorization{Tv, Ti},
   T::SparseMatrixCSC{Tv, Ti},
-  adiag::AbstractVector{Tv},
-  S::LimitedLDLFactorization{Tv, Ti};
+  adiag::AbstractVector{Tv};
   droptol::Tv = Tv(0),
 ) where {Tv <: Number, Ti <: Integer}
 
@@ -395,8 +395,8 @@ function lldl(
   α::Tv = Tv(0),
   droptol::Tv = Tv(0),
 ) where {Tv <: Number, Ti <: Integer}
-  S = lldl_allocate(T, adiag, P; memory = memory, α = α)
-  lldl_factorize!(T, adiag, S, droptol = droptol)
+  S = LimitedLDLFactorization(T, adiag, P; memory = memory, α = α)
+  lldl_factorize!(S, T, adiag, droptol = droptol)
 end
 
 function attempt_lldl!(

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -132,8 +132,8 @@ end
   A = sparse(A)
   Alow, adiag = tril(A, -1), diag(A)
   perm = amd(A)
-  LLDL = lldl_allocate(Alow, adiag, perm, memory = 10)
-  lldl_factorize!(Alow, adiag, LLDL)
+  LLDL = LimitedLDLFactorization(Alow, adiag, perm, memory = 10)
+  lldl_factorize!(LLDL, Alow, adiag)
   @test LLDL.α == 0
   L = LLDL.L + I
   @test norm(L * diagm(0 => LLDL.D) * L' - A[perm, perm]) ≤ sqrt(eps()) * norm(A)
@@ -164,7 +164,7 @@ end
   ]
   A2 = sparse(A2)
   A2low, a2diag = tril(A2, -1), diag(A2)
-  lldl_factorize!(A2low, a2diag, LLDL)
+  lldl_factorize!(LLDL, A2low, a2diag)
   @test LLDL.α == 0
   L = LLDL.L + I
   @test norm(L * diagm(0 => LLDL.D) * L' - A2[perm, perm]) ≤ sqrt(eps()) * norm(A2)


### PR DESCRIPTION
All the elements of `adiag` should keep their sign.

`LLDL.L` now allocates in order to keep the existing behaviour but I can change it to something like
```julia
get_L_factor(LLDL) = ...
```
if that is an issue.
