### PR TITLE
Lower triangular with diagonal input matrix

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -4,7 +4,7 @@ task:
   name: FreeBSD
   env:
     matrix:
-      - JULIA_VERSION: 1.4
+      - JULIA_VERSION: 1.6
       - JULIA_VERSION: 1
       - JULIA_VERSION: nightly
   allow_failures: $JULIA_VERSION == 'nightly'

--- a/Project.toml
+++ b/Project.toml
@@ -8,7 +8,7 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [compat]
-julia = "^1.4.0"
+julia = "^1.6.0"
 AMD = "0.4, 0.5"
 
 [extras]

--- a/src/LimitedLDLFactorizations.jl
+++ b/src/LimitedLDLFactorizations.jl
@@ -38,7 +38,7 @@ mutable struct LimitedLDLFactorization{
   lvals::Vector{T}
   Lnzvals::SubArray{T, 1, Vector{T}, Tuple{UnitRange{Int}}, true}
 
-  nb_diag_elements::Int
+  nnz_diag::Int
   adiag::Vector{T}
 
   D::Vector{T}
@@ -71,13 +71,13 @@ function LimitedLDLFactorization(
   np = n * memory
   Pinv = similar(P)
 
-  nb_diag_elements = 0
+  nnz_diag = 0
   adiag = Vector{Tv}(undef, n)
   for col = 1:n
     k = T.colptr[col]
     row = (k ≤ nnzT) ? T.rowval[k] : 0
     if row == col
-      nb_diag_elements += 1
+      nnz_diag += 1
       adiag[col] = T.nzval[k]
     else
       adiag[col] = zero(Tv)
@@ -85,7 +85,7 @@ function LimitedLDLFactorization(
   end
 
   # Make room to store L.
-  nnzLmax = nnzT + np - nb_diag_elements
+  nnzLmax = nnzT + np - nnz_diag
   d = Vector{Tv}(undef, n)  # Diagonal matrix D.
   lvals = Vector{Tv}(undef, nnzLmax)  # Strict lower triangle of L.
   rowind = Vector{Ti}(undef, nnzLmax)
@@ -112,7 +112,7 @@ function LimitedLDLFactorization(
     Lrowind,
     lvals,
     Lnzvals,
-    nb_diag_elements,
+    nnz_diag,
     adiag,
     d,
     P,
@@ -190,7 +190,7 @@ function lldl_factorize!(
   Lnzvals = S.Lnzvals
 
   nnzT = nnz(T)
-  nnzT_nodiag = nnzT - S.nb_diag_elements
+  nnzT_nodiag = nnzT - S.nnz_diag
   memory = S.memory
   α = S.α
 

--- a/src/LimitedLDLFactorizations.jl
+++ b/src/LimitedLDLFactorizations.jl
@@ -161,11 +161,11 @@ function LimitedLDLFactorization(
   return LimitedLDLFactorization(T, P, memory, α, n, nnz(T))
 end
 
-# Here T is the strict lower triangle of A.
+# Here T is the lower triangle of A.
 """
     lldl_factorize!(S, T; droptol = 0.0)
 
-Perform the in-place factorization of a symmetric matrix whose lower triangle is `T` and diagonal is `d` 
+Perform the in-place factorization of a symmetric matrix whose lower triangle is `T` 
 with the permutation vector.
 
 # Arguments
@@ -226,7 +226,7 @@ function lldl_factorize!(
       val = T.nzval[k]
       val2 = val * val
       wa1[Pinv[col]] += val2  # Contribution to column Pinv[col].
-      wa1[Pinv[row]] += val2  # Contribution to column Pinv[T.rowval[k]].
+      wa1[Pinv[row]] += val2  # Contribution to column Pinv[row].
     end
   end
 
@@ -365,7 +365,7 @@ end
 """
     lldl(A)
 
-Compute the limited-memory LDLᵀ factorization of `A` without pivoting.
+Compute the limited-memory LDLᵀ factorization of `A`.
 `A` should be a lower triangular matrix.
 
 # Arguments
@@ -397,7 +397,7 @@ function lldl(
   lldl_factorize!(S, T, droptol = droptol)
 end
 
-lldl(A::Array{Tv, 2}; kwargs...) where {Tv <: Number} = lldl(sparse(A); kwargs...)
+lldl(A::Matrix{Tv}; kwargs...) where {Tv <: Number} = lldl(sparse(A); kwargs...)
 
 # symmetric matrix input
 function lldl(

--- a/src/LimitedLDLFactorizations.jl
+++ b/src/LimitedLDLFactorizations.jl
@@ -38,6 +38,9 @@ mutable struct LimitedLDLFactorization{
   lvals::Vector{T}
   Lnzvals::SubArray{T, 1, Vector{T}, Tuple{UnitRange{Int}}, true}
 
+  nb_diag_elements::Int
+  adiag::Vector{T}
+
   D::Vector{T}
   P::V1
   α::T
@@ -51,70 +54,38 @@ mutable struct LimitedLDLFactorization{
   indr::Vector{Ti}
   indf::Vector{Ti}
   list::Vector{Ti}
-  pos::Vector{Ti}
-  neg::Vector{Ti}
+  pos::Vector{Int}
+  neg::Vector{Int}
 
   computed_posneg::Bool # true if pos and neg are computed (becomes false after factorization)
 end
 
-lldl(A::Array{Tv, 2}; kwargs...) where {Tv <: Number} = lldl(sparse(A); kwargs...)
-
-"""
-    lldl(A)
-
-Compute the limited-memory LDLᵀ factorization of A without pivoting.
-
-# Arguments
-- `A::SparseMatrixCSC{Tv,Ti}`: matrix to factorize (its strict lower triangle and
-                               diagonal will be extracted)
-
-# Keyword arguments
-- `memory::Int=0`: extra amount of memory to allocate for the incomplete factor `L`.
-                   The total memory allocated is nnz(T) + n * `memory`, where
-                   `T` is the strict lower triangle of A and `n` is the size of `A`.
-- `α::Tv=Tv(0)`: initial value of the shift in case the incomplete LDLᵀ
-                 factorization of `A` is found to not exist. The shift will be
-                 gradually increased from this initial value until success.
-- `droptol::Tv=Tv(0)`: to further sparsify `L`, all elements with magnitude smaller
-                       than `droptol` are dropped.
-"""
-function lldl(A::SparseMatrixCSC{Tv, Ti}; kwargs...) where {Tv <: Number, Ti <: Integer}
-  lldl(tril(A, -1), diag(A), amd(A); kwargs...)
-end
-
-function lldl(
-  A::SparseMatrixCSC{Tv, Ti},
-  P::AbstractVector{<:Integer};
-  kwargs...,
-) where {Tv <: Number, Ti <: Integer}
-  lldl(tril(A, -1), diag(A), P; kwargs...)
-end
-
-# symmetric matrix input
-function lldl(
-  sA::Symmetric{T, SparseMatrixCSC{T, Ti}},
-  args...;
-  kwargs...,
-) where {T <: Real, Ti <: Integer}
-  sA.uplo == 'U' && error("matrix must contain the lower triangle")
-  A = sA.data
-  lldl(A, args...; kwargs...)
-end
-
 function LimitedLDLFactorization(
-  adiag::AbstractVector{Tv},
+  T::SparseMatrixCSC{Tv, Ti},
   P::AbstractVector{<:Integer},
-  Ti::DataType,
   memory::Int,
   α::Tv,
   n::Int,
   nnzT::Int,
-) where {Tv <: Number}
+) where {Tv <: Number, Ti}
   np = n * memory
   Pinv = similar(P)
 
+  nb_diag_elements = 0
+  adiag = Vector{Tv}(undef, n)
+  for col = 1:n
+    k = T.colptr[col]
+    row = (k ≤ nnzT) ? T.rowval[k] : 0
+    if row == col
+      nb_diag_elements += 1
+      adiag[col] = T.nzval[k]
+    else
+      adiag[col] = zero(Tv)
+    end
+  end
+
   # Make room to store L.
-  nnzLmax = nnzT + np
+  nnzLmax = nnzT + np - nb_diag_elements
   d = Vector{Tv}(undef, n)  # Diagonal matrix D.
   lvals = Vector{Tv}(undef, nnzLmax)  # Strict lower triangle of L.
   rowind = Vector{Ti}(undef, nnzLmax)
@@ -141,6 +112,8 @@ function LimitedLDLFactorization(
     Lrowind,
     lvals,
     Lnzvals,
+    nb_diag_elements,
+    adiag,
     d,
     P,
     α,
@@ -159,17 +132,16 @@ function LimitedLDLFactorization(
 end
 
 """
-    LLDL = LimitedLDLFactorization(T, adiag, P; memory = 0, α = 0.0)
+    LLDL = LimitedLDLFactorization(T, P; memory = 0, α = 0.0)
 
 Perform the allocations for the LLDL factorization of symmetric matrix whose lower triangle is `T` 
-and diagonal is `d` with the permutation vector `P`.
+with the permutation vector `P`.
 
 # Arguments
 - `T::SparseMatrixCSC{Tv,Ti}`: lower triangle of the matrix to factorize.
-- `adiag::AbstractVector{Tv}`: diagonal of the matrix to factorize.
-- `P::AbstractVector{<:Integer}`: permutation vector.
 
 # Keyword arguments
+- `P::AbstractVector{<:Integer} = amd(T)`: permutation vector.
 - `memory::Int=0`: extra amount of memory to allocate for the incomplete factor `L`.
                    The total memory allocated is nnz(T) + n * `memory`, where
                    `T` is the strict lower triangle of A and `n` is the size of `A`.
@@ -178,22 +150,20 @@ and diagonal is `d` with the permutation vector `P`.
                  gradually increased from this initial value until success.
 """
 function LimitedLDLFactorization(
-  T::SparseMatrixCSC{Tv, Ti},
-  adiag::AbstractVector{Tv},
-  P::AbstractVector{<:Integer};
+  T::SparseMatrixCSC{Tv, Ti};
+  P::AbstractVector{<:Integer} = amd(T),
   memory::Int = 0,
   α::Tv = Tv(0),
 ) where {Tv <: Number, Ti <: Integer}
   memory < 0 && error("limited-memory parameter must be nonnegative")
   n = size(T, 1)
   n != size(T, 2) && error("input matrix must be square")
-  n != length(adiag) && error("inconsistent size of diagonal")
-  return LimitedLDLFactorization(adiag, P, Ti, memory, α, n, nnz(T))
+  return LimitedLDLFactorization(T, P, memory, α, n, nnz(T))
 end
 
 # Here T is the strict lower triangle of A.
 """
-    lldl_factorize!(S, T, adiag; droptol = 0.0)
+    lldl_factorize!(S, T; droptol = 0.0)
 
 Perform the in-place factorization of a symmetric matrix whose lower triangle is `T` and diagonal is `d` 
 with the permutation vector.
@@ -201,8 +171,7 @@ with the permutation vector.
 # Arguments
 - `S::LimitedLDLFactorization{Tv, Ti}`.
 - `T::SparseMatrixCSC{Tv,Ti}`: lower triangle of the matrix to factorize.
-- `adiag::AbstractVector{Tv}`: diagonal of the matrix to factorize.
-`T` should keep the same nonzero pattern and `adiag` should keep the sign of its elements.
+`T` should keep the same nonzero pattern and the sign of its diagonal elements.
 
 # Keyword arguments
 - `droptol::Tv=Tv(0)`: to further sparsify `L`, all elements with magnitude smaller
@@ -210,21 +179,19 @@ with the permutation vector.
 """
 function lldl_factorize!(
   S::LimitedLDLFactorization{Tv, Ti},
-  T::SparseMatrixCSC{Tv, Ti},
-  adiag::AbstractVector{Tv};
+  T::SparseMatrixCSC{Tv, Ti};
   droptol::Tv = Tv(0),
 ) where {Tv <: Number, Ti <: Integer}
   n = size(T, 1)
   n != size(T, 2) && error("input matrix must be square")
-  n != length(adiag) && error("inconsistent size of diagonal")
 
   colptr = S.colptr
   Lrowind = S.Lrowind
   Lnzvals = S.Lnzvals
 
   nnzT = nnz(T)
+  nnzT_nodiag = nnzT - S.nb_diag_elements
   memory = S.memory
-  np = n * memory
   α = S.α
 
   P = S.P
@@ -232,6 +199,13 @@ function lldl_factorize!(
   # Compute inverse permutation
   @inbounds for k = 1:n
     Pinv[P[k]] = k
+  end
+
+  adiag = S.adiag
+  for col = 1:n
+    k = T.colptr[col]
+    row = (k ≤ nnzT) ? T.rowval[k] : 0
+    adiag[col] = (row == col) ? T.nzval[k] : zero(Tv)
   end
 
   d = S.D  # Diagonal matrix D.
@@ -244,13 +218,15 @@ function lldl_factorize!(
   wa1 = S.wa1
   wa1 .= zero(Tv)
   s = S.s
-  @inbounds @simd for col = 1:n
+  @inbounds for col = 1:n
     s[col] = Tv(1) # Initialization
-    @inbounds @simd for k = T.colptr[col]:(T.colptr[col + 1] - 1)
+    @inbounds for k = T.colptr[col]:(T.colptr[col + 1] - 1)
+      row = T.rowval[k]
+      (row == col) && continue
       val = T.nzval[k]
       val2 = val * val
       wa1[Pinv[col]] += val2  # Contribution to column Pinv[col].
-      wa1[Pinv[T.rowval[k]]] += val2  # Contribution to column Pinv[T.rowval[k]].
+      wa1[Pinv[row]] += val2  # Contribution to column Pinv[T.rowval[k]].
     end
   end
 
@@ -307,8 +283,9 @@ function lldl_factorize!(
     fill!(indr, 0)
     @inbounds for col = 1:n
       @inbounds for k = T.colptr[col]:(T.colptr[col + 1] - 1)
-        row = Pinv[T.rowval[k]]
-        indr[min(row, Pinv[col])] += one(Ti)
+        row = T.rowval[k]
+        (row == col) && continue
+        indr[min(Pinv[row], Pinv[col])] += one(Ti)
       end
     end
     # cumulative sum
@@ -329,11 +306,13 @@ function lldl_factorize!(
       scol = s[pinvcol]
       d[pinvcol] = adiag[col] * scol * scol
       @inbounds for k = T.colptr[col]:(T.colptr[col + 1] - 1)
-        row = Pinv[T.rowval[k]]
-        q = indr[min(row, pinvcol)]
-        rowind[q] = max(row, pinvcol)
-        lvals[q] = T.nzval[k] * scol * s[row]
-        indr[min(row, pinvcol)] += one(Ti)
+        row = T.rowval[k]
+        (row == col) && continue
+        pinvrow = Pinv[row]
+        q = indr[min(pinvrow, pinvcol)]
+        rowind[q] = max(pinvrow, pinvcol)
+        lvals[q] = T.nzval[k] * scol * s[pinvrow]
+        indr[min(pinvrow, pinvcol)] += one(Ti)
       end
     end
 
@@ -346,7 +325,7 @@ function lldl_factorize!(
 
     # Attempt a factorization.
     factorized = attempt_lldl!(
-      nnzT,
+      nnzT_nodiag,
       d,
       lvals,
       rowind,
@@ -383,16 +362,48 @@ function lldl_factorize!(
   return S
 end
 
+"""
+    lldl(A)
+
+Compute the limited-memory LDLᵀ factorization of `A` without pivoting.
+`A` should be a lower triangular matrix.
+
+# Arguments
+- `A::SparseMatrixCSC{Tv,Ti}`: matrix to factorize (its strict lower triangle and
+                               diagonal will be extracted)
+
+# Keyword arguments
+- `P::AbstractVector{<:Integer} = amd(A)`: permutation vector.
+- `memory::Int=0`: extra amount of memory to allocate for the incomplete factor `L`.
+                   The total memory allocated is nnz(T) + n * `memory`, where
+                   `T` is the strict lower triangle of A and `n` is the size of `A`.
+- `α::Tv=Tv(0)`: initial value of the shift in case the incomplete LDLᵀ
+                 factorization of `A` is found to not exist. The shift will be
+                 gradually increased from this initial value until success.
+- `droptol::Tv=Tv(0)`: to further sparsify `L`, all elements with magnitude smaller
+                       than `droptol` are dropped.
+- `check_tril::Bool = true`: check if `A` is a lower triangular matrix. 
+"""
 function lldl(
-  T::SparseMatrixCSC{Tv, Ti},
-  adiag::AbstractVector{Tv},
-  P::AbstractVector{<:Integer};
+  A::SparseMatrixCSC{Tv, Ti};
+  P::AbstractVector{<:Integer} = amd(A),
   memory::Int = 0,
   α::Tv = Tv(0),
   droptol::Tv = Tv(0),
+  check_tril::Bool = true,
 ) where {Tv <: Number, Ti <: Integer}
-  S = LimitedLDLFactorization(T, adiag, P; memory = memory, α = α)
-  lldl_factorize!(S, T, adiag, droptol = droptol)
+  T = (!check_tril || istril(A)) ? A : tril(A)
+  S = LimitedLDLFactorization(T; P = P, memory = memory, α = α)
+  lldl_factorize!(S, T, droptol = droptol)
+end
+
+lldl(A::Array{Tv, 2}; kwargs...) where {Tv <: Number} = lldl(sparse(A); kwargs...)
+
+# symmetric matrix input
+function lldl(sA::Symmetric{T, SparseMatrixCSC{T, Ti}}; kwargs...) where {T <: Real, Ti <: Integer}
+  sA.uplo == 'U' && error("matrix must contain the lower triangle")
+  A = sA.data
+  lldl(A; kwargs...)
 end
 
 function attempt_lldl!(

--- a/src/LimitedLDLFactorizations.jl
+++ b/src/LimitedLDLFactorizations.jl
@@ -400,7 +400,10 @@ end
 lldl(A::Array{Tv, 2}; kwargs...) where {Tv <: Number} = lldl(sparse(A); kwargs...)
 
 # symmetric matrix input
-function lldl(sA::Symmetric{T, SparseMatrixCSC{T, Ti}}; kwargs...) where {T <: Real, Ti <: Integer}
+function lldl(
+  sA::Union{Symmetric{T, SparseMatrixCSC{T, Ti}}, Hermitian{T, SparseMatrixCSC{T, Ti}}};
+  kwargs...
+) where {T <: Real, Ti <: Integer}
   sA.uplo == 'U' && error("matrix must contain the lower triangle")
   A = sA.data
   lldl(A; kwargs...)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -24,7 +24,7 @@ using AMD, Metis, LimitedLDLFactorizations
     @test nnzl0 == nnz(tril(A))
     @test LLDL.α == 0
 
-    LLDL = lldl(A, P = perm, memory = 5)
+    LLDL = lldl(Symmetric(A, :L), P = perm, memory = 5) # test symmetric lldl
     nnzl5 = nnz(LLDL)
     @test nnzl5 ≥ nnzl0
     @test LLDL.α == 0
@@ -165,6 +165,8 @@ end
   A2 = sparse(A2)
   A2low = tril(A2)
   lldl_factorize!(LLDL, A2low)
+  allocs = @allocated lldl_factorize!(LLDL, A2low)
+  @test allocs == 0
   @test LLDL.α == 0
   L = LLDL.L + I
   @test norm(L * diagm(0 => LLDL.D) * L' - A2[perm, perm]) ≤ sqrt(eps()) * norm(A2)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -19,17 +19,17 @@ using AMD, Metis, LimitedLDLFactorizations
   A = sparse(A)
 
   for perm ∈ (1:(A.n), amd(A), Metis.permutation(A)[1])
-    LLDL = lldl(A, perm, memory = 0)
+    LLDL = lldl(A, P = perm, memory = 0)
     nnzl0 = nnz(LLDL)
     @test nnzl0 == nnz(tril(A))
     @test LLDL.α == 0
 
-    LLDL = lldl(A, perm, memory = 5)
+    LLDL = lldl(A, P = perm, memory = 5)
     nnzl5 = nnz(LLDL)
     @test nnzl5 ≥ nnzl0
     @test LLDL.α == 0
 
-    LLDL = lldl(A, perm, memory = 10)
+    LLDL = lldl(A, P = perm, memory = 10)
     @test nnz(LLDL) ≥ nnzl5
     @test LLDL.α == 0
     L = LLDL.L + I
@@ -85,17 +85,17 @@ end
   B = tril(A)
 
   for perm ∈ (1:(A.n), amd(A), Metis.permutation(A)[1])
-    LLDL = lldl(B, perm, memory = 0)
+    LLDL = lldl(B, P = perm, memory = 0)
     nnzl0 = nnz(LLDL)
     @test nnzl0 == nnz(tril(A))
     @test LLDL.α == 0
 
-    LLDL = lldl(B, perm, memory = 5)
+    LLDL = lldl(B, P = perm, memory = 5)
     nnzl5 = nnz(LLDL)
     @test nnzl5 ≥ nnzl0
     @test LLDL.α == 0
 
-    LLDL = lldl(B, perm, memory = 10)
+    LLDL = lldl(B, P = perm, memory = 10)
     @test nnz(LLDL) ≥ nnzl5
     @test LLDL.α == 0
     L = LLDL.L + I
@@ -130,10 +130,10 @@ end
     0 0.01 0 0 0.53 0 0.56 0 0 3.1
   ]
   A = sparse(A)
-  Alow, adiag = tril(A, -1), diag(A)
+  Alow = tril(A)
   perm = amd(A)
-  LLDL = LimitedLDLFactorization(Alow, adiag, perm, memory = 10)
-  lldl_factorize!(LLDL, Alow, adiag)
+  LLDL = LimitedLDLFactorization(Alow, P = perm, memory = 10)
+  lldl_factorize!(LLDL, Alow)
   @test LLDL.α == 0
   L = LLDL.L + I
   @test norm(L * diagm(0 => LLDL.D) * L' - A[perm, perm]) ≤ sqrt(eps()) * norm(A)
@@ -163,8 +163,8 @@ end
     0 0.01 0 0 0.53 0 1.56 0 0 30.1
   ]
   A2 = sparse(A2)
-  A2low, a2diag = tril(A2, -1), diag(A2)
-  lldl_factorize!(LLDL, A2low, a2diag)
+  A2low = tril(A2)
+  lldl_factorize!(LLDL, A2low)
   @test LLDL.α == 0
   L = LLDL.L + I
   @test norm(L * diagm(0 => LLDL.D) * L' - A2[perm, perm]) ≤ sqrt(eps()) * norm(A2)


### PR DESCRIPTION
The matrix used by the factorization is now lower triangular with the diagonal, instead of being separated in a strict lower triangular matrix and the diagonal elements.

The `lldl` and `LimitedLDLFactorization` function arguments have been modified to be more convenient to use with these changes.
In particular, the permutation vector `P` is now a keyword argument.

`adiag` was previously computed with `diag(A)`, which produces a `SparseVector`. It is now a `Vector` that may have some zeros, because I thought it would be faster to access its elements. This change forces the types of `pos`  and `neg` to be always `Int64` because they are computed with `findall`, but I don't think this is an issue.