### PR TITLE
Fixing dispatch/method specialization error

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -5,13 +5,7 @@ task:
         image_family: freebsd-14-2
       env:
         matrix:
-          - JULIA_VERSION: 'lts'
           - JULIA_VERSION: '1'
-    - name: MacOS M1
-      macos_instance:
-        image: ghcr.io/cirruslabs/macos-monterey-base:latest
-      env:
-        - JULIA_VERSION: 1
   install_script: |
     URL="https://raw.githubusercontent.com/ararslan/CirrusCI.jl/master/bin/install.sh"
     set -x

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,30 +13,38 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: ['1.6', '1']
-        os: [ubuntu-latest, macOS-latest, windows-latest]
+        version: ['lts', '1']
+        os: [ubuntu-latest, macos-latest, windows-latest]
         arch: [x64]
         allow_failure: [false]
         include:
-          - version: 'nightly'
+          - version: '1'
+            os: ubuntu-24.04-arm
+            arch: arm64
+            allow_failure: false
+          - version: '1'
+            os: macos-latest
+            arch: arm64
+            allow_failure: false
+          - version: 'pre'
             os: ubuntu-latest
             arch: x64
             allow_failure: true
-          - version: 'nightly'
-            os: macOS-latest
+          - version: 'pre'
+            os: macos-latest
             arch: x64
             allow_failure: true
-          - version: 'nightly'
+          - version: 'pre'
             os: windows-latest
             arch: x64
             allow_failure: true
     steps:
-      - uses: actions/checkout@v2
-      - uses: julia-actions/setup-julia@v1
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: actions/cache@v1
+      - uses: actions/cache@v4
         env:
           cache-name: cache-artifacts
         with:
@@ -49,6 +57,6 @@ jobs:
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v1
+      - uses: codecov/codecov-action@v5
         with:
-          file: lcov.info
+          files: lcov.info

--- a/src/LimitedLDLFactorizations.jl
+++ b/src/LimitedLDLFactorizations.jl
@@ -845,31 +845,21 @@ function lldl_solve!(n, B::AbstractMatrix, Lp, Li, Lx, D, P)
   return B
 end
 
-import Base.(\)
-(\)(LLDL::LimitedLDLFactorization, b::AbstractVector) = ldiv!(LLDL, copy(b))
-(\)(LLDL::LimitedLDLFactorization, B::AbstractMatrix) = ldiv!(LLDL, copy(B))
-
-import LinearAlgebra.ldiv!
-function ldiv!(LLDL::LimitedLDLFactorization, b::AbstractVector)
+function _ldiv!(LLDL::LimitedLDLFactorization, b)
   factorized(LLDL) || throw(LLDLException(error_string))
   lldl_solve!(LLDL.n, b, LLDL.colptr, LLDL.Lrowind, LLDL.Lnzvals, LLDL.D, LLDL.P)
 end
-function ldiv!(LLDL::LimitedLDLFactorization, B::AbstractMatrix)
-  factorized(LLDL) || throw(LLDLException(error_string))
-  lldl_solve!(LLDL.n, B, LLDL.colptr, LLDL.Lrowind, LLDL.Lnzvals, LLDL.D, LLDL.P)
-end
+LinearAlgebra.ldiv!(LLDL::LimitedLDLFactorization, b)    = _ldiv!(LLDL, b)
 
-function ldiv!(y::AbstractVector, LLDL::LimitedLDLFactorization, b::AbstractVector)
+function _ldiv!(y, LLDL::LimitedLDLFactorization, b)
   y .= b
   ldiv!(LLDL, y)
 end
-function ldiv!(Y::AbstractMatrix, LLDL::LimitedLDLFactorization, B::AbstractMatrix)
-  Y .= B
-  ldiv!(LLDL, Y)
-end
+LinearAlgebra.ldiv!(y, LLDL::LimitedLDLFactorization, b) = _ldiv!(y, LLDL, b)
 
-import SparseArrays.nnz
-nnz(LLDL::LimitedLDLFactorization) = length(LLDL.Lrowind) + length(LLDL.D)
+Base.:\(LLDL::LimitedLDLFactorization, b) = ldiv!(LLDL, copy(b))
+
+SparseArrays.nnz(LLDL::LimitedLDLFactorization) = length(LLDL.Lrowind) + length(LLDL.D)
 
 function Base.getproperty(LLDL::LimitedLDLFactorization, prop::Symbol)
   if prop == :L

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -35,17 +35,20 @@ using AMD, Metis, LimitedLDLFactorizations
     L = LLDL.L + I
     @test norm(L * diagm(0 => LLDL.D) * L' - A[perm, perm]) ≤ sqrt(eps()) * norm(A)
 
-    sol = ones(A.n)
-    b = A * sol
-    x = LLDL \ b
-    @test x ≈ sol
+    for sol in (ones(A.n), ones(A.n, 3)) # testing Vector{Float64} and Matrix{Float64} RHS
+      b = A * sol
+      x = LLDL \ b
+      @test x ≈ sol
 
-    y = similar(b)
-    ldiv!(y, LLDL, b)
-    @test y ≈ sol
+      y = similar(b)
+      ldiv!(y, LLDL, b)
+      @test y ≈ sol
 
-    ldiv!(LLDL, b)
-    @test b ≈ sol
+      ldiv!(LLDL, b)
+      @test b ≈ sol
+
+    end
+
   end
 end
 


### PR DESCRIPTION
Hi @dpo and company---

Thanks for the great package! As I've been tinkering with it, I've caught an issue that the special `ldiv!` methods for matrices sometimes seem not to get hit. Here is a demonstration:

```julia
using LinearAlgebra, SparseArrays, LimitedLDLFactorizations

n  = 100
S  = sprandn(n, n, 1/n) + 100*I
pr = lldl(S; memory=2)
v1 = randn(n)
v2 = randn(n, 10)

println("Trying vector ldiv!:")
ldiv!(pr, v1)
println("...done.")

println("Trying matrix ldiv!:")
ldiv!(pr, v2)
println("...done.")
```

On the current release, this is what you get when you run this program (also with a `versioninfo()` for your information):
```
cg:lldl> julia --project --quiet
julia> versioninfo()
Julia Version 1.11.5
Commit 760b2e5b739 (2025-04-14 06:53 UTC)
Build Info:
  Official https://julialang.org/ release
Platform Info:
  OS: Linux (x86_64-linux-gnu)
  CPU: 12 × 12th Gen Intel(R) Core(TM) i7-1260P
  WORD_SIZE: 64
  LLVM: libLLVM-16.0.6 (ORCJIT, alderlake)
Threads: 1 default, 0 interactive, 1 GC (on 12 virtual cores)
Environment:
  LD_LIBRARY_PATH = :/opt/knitro-13.2.0-Linux-64/lib:/opt/knitro-13.2.0-Linux-64/lib:/opt/knitro-13.2.0-Linux-64/lib

julia> include("testlldl.jl")
Trying vector ldiv!:
...done.
Trying matrix ldiv!:
ERROR: LoadError: MethodError: no method matching ldiv!(::LimitedLDLFactorization{Float64, Int64, Vector{Int64}, Vector{Int64}}, ::Matrix{Float64})
The function `ldiv!` exists, but no method is defined for this combination of argument types.

Closest candidates are:
  ldiv!(::Cholesky{T, <:StridedMatrix{T} where T}, ::StridedVecOrMat{T}) where T<:Union{Float32, Float64, ComplexF64, ComplexF32}
   @ LinearAlgebra ~/.julia/juliaup/julia-1.11.5+0.x64.linux.gnu/share/julia/stdlib/v1.11/LinearAlgebra/src/cholesky.jl:579
  ldiv!(::Cholesky, ::AbstractVecOrMat)
   @ LinearAlgebra ~/.julia/juliaup/julia-1.11.5+0.x64.linux.gnu/share/julia/stdlib/v1.11/LinearAlgebra/src/cholesky.jl:582
  ldiv!(::LinearAlgebra.AbstractQ, ::AbstractVecOrMat)
   @ LinearAlgebra ~/.julia/juliaup/julia-1.11.5+0.x64.linux.gnu/share/julia/stdlib/v1.11/LinearAlgebra/src/abstractq.jl:246
  ...

Stacktrace:
 [1] top-level scope
   @ ~/Scratch/lldl/testlldl.jl:15
 [2] include(fname::String)
   @ Main ./sysimg.jl:38
 [3] top-level scope
   @ REPL[2]:1
in expression starting at /home/cg/Scratch/lldl/testlldl.jl:15
```
So it seems like `ldiv!` for an LLDL object and a `Matrix` is not hitting the special branch.

This PR makes just a few small tweaks to fix this. First, I split your special `ldiv!` methods into non-exported `_ldiv!`, which at least personally I find preferable so that if dispatch breaks or something I can at least import an internal method and not have to drop what I'm doing to catch something. Second, the code previously defined `ldiv!` for both `AbstractVector` and `AbstractMatrix` separately. But that dispatch is handled by the methods of `lldl_solve!`, so I don't think the different `ldiv!`s are necessary and I removed them.

The tests and everything still pass. Is there any other way that you'd like me to kick the tires on the change? Or any other formatting preferences you'd like this PR to adhere to?